### PR TITLE
Add docker-build workflow for main branch merges

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,218 @@
+name: Docker Build and Test
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  GIT_USER_NAME: GitHub Pipeline
+  GIT_USER_EMAIL: github_pipeline@fairagro.net
+  IMAGE_NAME: fairagro_advanced_middleware_api
+  DOCKERHUB_NAMESPACE: zalf
+  IMAGE_TITLE: FairAgro Advanced Middleware API
+  IMAGE_DESCRIPTION: Advanced middleware API for FairAgro platform
+  # Derived static variables
+  GITVERSION_TAG_PREFIX: '.*-docker-v'
+  DOCKER_PLATFORMS: linux/amd64
+  SBOM_FORMAT: spdx-json
+  # Main branch settings
+  RELEASE_TYPE: main-build
+  VERSION_INCREMENT: patch
+  CREATE_GITHUB_RELEASE: false
+  IS_FEATURE_BRANCH: false
+
+jobs:
+  calculate-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.gitversion.outputs.majorMinorPatch }}
+      release-type: main-build
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gittools/actions/gitversion/setup@v4
+        with:
+          versionSpec: '6.x'
+
+      - name: Configure GitVersion
+        run: |
+          cat > GitVersion.yml << EOF
+          mode: ContinuousDeployment
+          tag-prefix: '.*-docker-v'
+          semantic-version-format: Strict
+          branches:
+            main:
+              label: ''
+              increment: Patch
+            feature:
+              regex: ^feature/(?<BranchName>.+)$
+              label: '{BranchName}'
+              increment: Inherit
+          EOF
+
+      - uses: gittools/actions/gitversion/execute@v4
+        id: gitversion
+
+      - name: Display version info
+        run: |
+          echo "🏷️ Calculated Version: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+          echo "📦 Build Type: Main branch build (no release)"
+
+  build-docker-image:
+    needs: calculate-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+      dockerhub-pushed: ${{ steps.push.outputs.pushed }}
+
+    env:
+      DOCKERHUB_AVAILABLE: ${{ secrets.DOCKERHUB_USER != '' && secrets.DOCKERHUB_TOKEN != '' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        if: env.DOCKERHUB_AVAILABLE == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_AVAILABLE == 'true' && format('{0}/{1}', env.DOCKERHUB_NAMESPACE, env.IMAGE_NAME) || '' }}
+          tags: |
+            type=raw,value=${{ needs.calculate-version.outputs.version }}
+            type=raw,value=latest,enable=true
+          labels: |
+            org.opencontainers.image.title=${{ env.IMAGE_TITLE }}
+            org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=v${{ needs.calculate-version.outputs.version }}
+            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ env.DOCKERHUB_AVAILABLE == 'true' }}
+          load: true
+          tags: |
+            local/${{ env.IMAGE_NAME }}:${{ needs.calculate-version.outputs.version }}
+            ${{ env.DOCKERHUB_AVAILABLE == 'true' && format('{0}/{1}:{2}', env.DOCKERHUB_NAMESPACE, env.IMAGE_NAME, needs.calculate-version.outputs.version) || '' }}
+            ${{ env.DOCKERHUB_AVAILABLE == 'true' && format('{0}/{1}:latest', env.DOCKERHUB_NAMESPACE, env.IMAGE_NAME) || '' }}
+          build-args: |
+            APP_VERSION=v${{ needs.calculate-version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: local/${{ env.IMAGE_NAME }}:${{ needs.calculate-version.outputs.version }}
+          format: ${{ env.SBOM_FORMAT }}
+          output-file: sbom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ needs.calculate-version.outputs.version }}
+          path: sbom.json
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: local/${{ env.IMAGE_NAME }}:${{ needs.calculate-version.outputs.version }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Set push status
+        id: push
+        run: |
+          if [[ "${{ env.DOCKERHUB_AVAILABLE }}" == "true" ]]; then
+            echo "pushed=true" >> $GITHUB_OUTPUT
+            echo "✅ Image pushed to DockerHub"
+          else
+            echo "pushed=false" >> $GITHUB_OUTPUT
+            echo "⏭️ DockerHub push skipped - missing secrets"
+          fi
+
+  container-structure-test:
+    needs: [calculate-version, build-docker-image]
+    runs-on: ubuntu-latest
+    if: needs.build-docker-image.result == 'success'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: test-image:latest
+          build-args: |
+            APP_VERSION=v${{ needs.calculate-version.outputs.version }}
+
+      - name: Download Container Structure Test
+        run: |
+          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
+          chmod +x container-structure-test-linux-amd64
+
+      - name: Run Container Structure Tests
+        run: |
+          ./container-structure-test-linux-amd64 test \
+            --image test-image:latest \
+            --config tests/container-structure-test.yaml \
+            --output junit \
+            --test-report container-structure-test-report.xml
+
+      - name: Upload Container Structure Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: container-structure-test-report
+          path: container-structure-test-report.xml
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## 🐳 Container Structure Test Summary" >> $GITHUB_STEP_SUMMARY
+          echo "**Image**: test-image:latest" >> $GITHUB_STEP_SUMMARY
+          echo "**Config**: tests/container-structure-test.yaml" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: v${{ needs.calculate-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Main branch build completed**" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker image built and tested" >> $GITHUB_STEP_SUMMARY
+          echo "- Container structure validated" >> $GITHUB_STEP_SUMMARY
+          echo "- Security scans completed" >> $GITHUB_STEP_SUMMARY
+          echo "- No releases created (main branch build only)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- New workflow triggers on push to main branch only
- Includes: calculate-version, build-docker-image, container-structure-test
- Excludes: create-release, update-helm-chart (no releases created)
- Builds and tests Docker images after feature branch merges
- Runs security scans (Trivy) and container structure validation
- Pushes to DockerHub if secrets available
- Generates SBOM for supply chain security
- Fixed end-of-file formatting

Purpose: Validate Docker builds on main without creating releases